### PR TITLE
Pandas import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pandas==1.5.*
+numpy==1.26.4
 sodapy==2.1.*
 pyproj==3.6.*
 openpyxl==3.1.*


### PR DESCRIPTION
I'm not sure what changed with my last PR (I didn't touch requirements.txt) but this error comes from Numpy not being compatible with Pandas.

> import pandas

> ValueError: numpy.dtype size changed, may indicate binary incompatibility.

Fix is to downgrade Numpy to an earlier version:
https://stackoverflow.com/a/78701492